### PR TITLE
Skip processing ghsa repos as security advisory forks do not have GH Actions enabled

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,6 +84,10 @@ func getAllWorkflowRuns(ctx context.Context, client *github.Client, repos []*git
     var allRuns []*github.WorkflowRun
     var err error
     for _, repo := range repos {
+        // Skip if repo name contains ghsa as security advisory forks do not have GH Actions enabled
+        if strings.Contains(repo.GetFullName(), "ghsa") {
+            continue
+        }
         var retries,retries2 int
         print(".")
         allRuns, retries, err = getWorkflowRunsByStatus(context.Background(), client, repo.GetFullName(), "in_progress", allRuns)


### PR DESCRIPTION
Skip processing ghsa repos as security advisory forks do not have GH Actions enabled

BEFORE:
```
 ./actions-usage quarkusio
Finding workflows running on all repositories on quarkusio...................................................................
  Error: GET https://api.github.com/repos/quarkusio/quarkus-ghsa-pv6m-j4fg-qx7h/actions/runs?per_page=100&status=in_progress: 404 Not Found []
```
AFTER:
```
 ./actions-usage quarkusio
... works as expected
```